### PR TITLE
Remove `eslint` from next.js config

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -7,7 +7,6 @@ module.exports = {
     // NEXT_PUBLIC_GTM_ID: process.env.NEXT_PUBLIC_GTM_ID,
     NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
   },
-  eslint: { ignoreDuringBuilds: true },
   poweredByHeader: false,
   reactStrictMode: true,
 };


### PR DESCRIPTION
`eslint` configuration in next.config.js is no longer supported